### PR TITLE
Fix drag and drop issue in image order

### DIFF
--- a/src/components/Layout/DragDrop/index.tsx
+++ b/src/components/Layout/DragDrop/index.tsx
@@ -16,16 +16,16 @@ export default function DragDrop({ scope = 'detail' }: { scope?: 'detail' | 'sim
     const target = images[srcIndex]
     console.log(srcIndex, destIndex, images[srcIndex])
     setInfo((prev) => {
-      const newImages = prev[scope][isDetail ? 'modelImages' : 'images']
+      const newImages = [...prev[scope].images]
 
       newImages.splice(srcIndex, 1)
       newImages.splice(destIndex, 0, target)
 
       return {
         ...prev,
-        detail: {
-          ...prev.detail,
-          modelImages: newImages,
+        [scope]: {
+          ...prev[scope],
+          images: newImages,
         },
       }
     })


### PR DESCRIPTION
Update the `onDragEnd` function to correctly update the `images` array.

* Remove the usage of `modelImages` in the `onDragEnd` function.
* Directly update the `images` array in the `onDragEnd` function.
* Modify the return object to update the `images` array within the appropriate scope.

